### PR TITLE
Switch to alpine as base image and add git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-slim
+FROM node:10-alpine
 
 LABEL version="1.0.0"
 LABEL repository="http://github.com/max/awesome-lint"
@@ -9,6 +9,10 @@ LABEL "com.github.actions.name"="GitHub Action for awesome-lint"
 LABEL "com.github.actions.description"="Wraps the awesome-lint tool to check awesome lists"
 LABEL "com.github.actions.icon"="play"
 LABEL "com.github.actions.color"="purple"
+
+RUN apk add --no-cache \
+  git \
+  && rm -rf /var/cache/apk/*
 
 RUN npm install -g awesome-lint
 


### PR DESCRIPTION
It turns out that `awesome-lint` requires `git` to validate that an awesome-list is indeed a valid Git repository. This PR adds `git` and at the same time switches to Alpine to keep the image size small.

Closes #1