### PR TITLE
Update Readme Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ keep them consistent.
 ```yaml
 steps:
   - uses: actions/checkout@v1.0.0
+    with:
+      fetch-depth: 0 # fetch repo history
   - uses: max/awesome-lint@v2.0.0
     with:
       filename: README.md # optional


### PR DESCRIPTION
This updates the `README` to enforce fetching the entire history, ensuring the linter runs as it should. This resolves #5.