### PR TITLE
bump Node container version to 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-alpine
+FROM node:18-alpine
 
 RUN apk add --no-cache \
   git \


### PR DESCRIPTION
More recent awesome-lint versions will require newer Node versions. See #7 for details.
Closes #7.